### PR TITLE
feat: Add keyboard navigation between chapters

### DIFF
--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/components/chapters'
 import { ProgressIndicator } from '@/components/ui'
 import { getLanguageColor } from '@/lib/constants'
-import { useScrollProgress } from '@/hooks'
+import { useScrollProgress, useKeyboardNavigation } from '@/hooks'
 import { cn } from '@/lib/utils'
 
 const CHAPTER_NAMES = ['Intro', 'Rhythm', 'Craft', 'Collaboration', 'Peak', 'Summary']
@@ -130,6 +130,9 @@ export default function DemoPage() {
   ]
 
   const { currentChapter } = useScrollProgress({ chapterRefs, containerRef: mainRef })
+
+  // Enable keyboard navigation (ArrowDown/Up, Space, PageDown/Up, Home/End)
+  useKeyboardNavigation({ chapterRefs, currentChapter })
 
   const scrollToChapter = (index: number) => {
     chapterRefs[index]?.current?.scrollIntoView({ behavior: 'smooth' })

--- a/src/app/rewind/page.tsx
+++ b/src/app/rewind/page.tsx
@@ -10,7 +10,7 @@ import {
   EpilogueChapter,
 } from '@/components/chapters'
 import { ProgressIndicator } from '@/components/ui'
-import { useScrollProgress } from '@/hooks'
+import { useScrollProgress, useKeyboardNavigation } from '@/hooks'
 import type { YearStats } from '@/lib/github'
 import { cn } from '@/lib/utils'
 import { getCached, setCache } from '@/lib/cache'
@@ -62,6 +62,9 @@ export default function RewindPage() {
   ]
 
   const { currentChapter } = useScrollProgress({ chapterRefs, containerRef: mainRef })
+
+  // Enable keyboard navigation (ArrowDown/Up, Space, PageDown/Up, Home/End)
+  useKeyboardNavigation({ chapterRefs, currentChapter })
 
   const scrollToChapter = (index: number) => {
     chapterRefs[index]?.current?.scrollIntoView({ behavior: 'smooth' })

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useScrollProgress } from './use-scroll-progress'
+export { useKeyboardNavigation } from './use-keyboard-navigation'

--- a/src/hooks/use-keyboard-navigation.ts
+++ b/src/hooks/use-keyboard-navigation.ts
@@ -1,0 +1,82 @@
+'use client'
+
+import { useEffect, useCallback, RefObject } from 'react'
+
+interface UseKeyboardNavigationOptions {
+  /** Refs to the chapter sections */
+  chapterRefs: RefObject<HTMLElement | null>[]
+  /** Current active chapter (1-indexed) */
+  currentChapter: number
+  /** Whether keyboard navigation is enabled (default: true) */
+  enabled?: boolean
+}
+
+/**
+ * Hook to enable keyboard navigation between chapters.
+ * - ArrowDown / Space / PageDown: Next chapter
+ * - ArrowUp / PageUp: Previous chapter
+ * - Home: First chapter
+ * - End: Last chapter
+ *
+ * Automatically disabled on touch devices.
+ */
+export function useKeyboardNavigation({
+  chapterRefs,
+  currentChapter,
+  enabled = true,
+}: UseKeyboardNavigationOptions) {
+  const scrollToChapter = useCallback((index: number) => {
+    const clampedIndex = Math.max(0, Math.min(index, chapterRefs.length - 1))
+    chapterRefs[clampedIndex]?.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [chapterRefs])
+
+  useEffect(() => {
+    // Disable on touch devices
+    const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0
+    if (!enabled || isTouchDevice) {
+      return
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Don't intercept if user is typing in an input
+      if (
+        event.target instanceof HTMLInputElement ||
+        event.target instanceof HTMLTextAreaElement ||
+        (event.target as HTMLElement).isContentEditable
+      ) {
+        return
+      }
+
+      switch (event.key) {
+        case 'ArrowDown':
+        case 'PageDown':
+          event.preventDefault()
+          scrollToChapter(currentChapter) // currentChapter is 1-indexed, so this goes to next
+          break
+        case ' ': // Space
+          // Only if not holding shift (shift+space = scroll up in browsers)
+          if (!event.shiftKey) {
+            event.preventDefault()
+            scrollToChapter(currentChapter)
+          }
+          break
+        case 'ArrowUp':
+        case 'PageUp':
+          event.preventDefault()
+          scrollToChapter(currentChapter - 2) // Go to previous (currentChapter is 1-indexed)
+          break
+        case 'Home':
+          event.preventDefault()
+          scrollToChapter(0)
+          break
+        case 'End':
+          event.preventDefault()
+          scrollToChapter(chapterRefs.length - 1)
+          break
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [enabled, currentChapter, chapterRefs.length, scrollToChapter])
+}


### PR DESCRIPTION
## Summary

Add keyboard navigation for desktop users to move between chapters in the rewind experience.

### Supported Keys
| Key | Action |
|-----|--------|
| `↓` ArrowDown | Next chapter |
| `↑` ArrowUp | Previous chapter |
| `Space` | Next chapter |
| `PageDown` | Next chapter |
| `PageUp` | Previous chapter |
| `Home` | First chapter |
| `End` | Last chapter |

### Implementation
- New `useKeyboardNavigation` hook in `src/hooks/`
- Automatically **disabled on touch devices** to avoid conflicts with mobile scrolling
- Ignores key events when user is typing in inputs

### Testing
1. Open the demo or rewind page on desktop
2. Press arrow keys to navigate between chapters
3. Verify smooth scrolling to snap points
4. Verify keyboard nav is disabled on mobile/touch devices