### PR TITLE
feat: Add conditional copy for sparse and zero activity

### DIFF
--- a/src/app/rewind/page.tsx
+++ b/src/app/rewind/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import {
   PrologueChapter,
   TheRhythmChapter,
@@ -18,6 +18,7 @@ import { downloadRewind } from '@/lib/export'
 import { compareYears, type YearComparison } from '@/lib/comparisons'
 import { comparisonLogger } from '@/lib/logger'
 import { formatFavoriteDays } from '@/lib/format-days'
+import { classifyActivityLevel } from '@/lib/activity-level'
 
 const CURRENT_YEAR = new Date().getFullYear()
 const AVAILABLE_YEARS = [CURRENT_YEAR, CURRENT_YEAR - 1, CURRENT_YEAR - 2]
@@ -208,6 +209,17 @@ export default function RewindPage() {
     fetchStats(selectedYear)
   }, [selectedYear, fetchStats])
 
+  // Compute activity level based on stats
+  const activityLevel = useMemo(() => {
+    if (!stats) {
+      return 'typical'
+    }
+    return classifyActivityLevel({
+      totalContributions: stats.totalContributions,
+      activeDays: stats.rhythm.activeDays,
+    })
+  }, [stats])
+
   if (error) {
     return (
       <main className="min-h-screen flex flex-col items-center justify-center px-6 text-center">
@@ -355,6 +367,7 @@ export default function RewindPage() {
           isLoading={loading}
           username={stats?.user.username}
           year={stats?.year}
+          activityLevel={activityLevel}
         />
       </div>
 
@@ -365,12 +378,17 @@ export default function RewindPage() {
           isLoading={loading}
           username={stats?.user.username}
           year={stats?.year}
+          activityLevel={activityLevel}
         />
       </div>
 
       {/* Chapter 3: The Collaboration */}
       <div ref={collaborationRef} className="snap-start snap-always">
-        <TheCollaborationChapter data={collaborationData} isLoading={loading} />
+        <TheCollaborationChapter
+          data={collaborationData}
+          isLoading={loading}
+          activityLevel={activityLevel}
+        />
       </div>
 
       {/* Chapter 4: Peak Moments */}
@@ -380,6 +398,7 @@ export default function RewindPage() {
           isLoading={loading}
           username={stats?.user.username}
           year={stats?.year}
+          activityLevel={activityLevel}
         />
       </div>
 
@@ -389,6 +408,7 @@ export default function RewindPage() {
           data={epilogueData}
           isLoading={loading}
           onDownload={stats ? () => downloadRewind(stats) : undefined}
+          activityLevel={activityLevel}
         />
       </div>
     </main>

--- a/src/components/chapters/epilogue.tsx
+++ b/src/components/chapters/epilogue.tsx
@@ -5,6 +5,11 @@ import { cn, pluralize } from '@/lib/utils'
 import { getLanguageColor } from '@/lib/constants'
 import { shareHighlight } from '@/lib/share'
 import { MethodologyModal } from '@/components/ui/methodology-modal'
+import { type ActivityLevel } from '@/lib/activity-level'
+import {
+  getEpilogueClosingMessage,
+  getEpilogueClosingContext,
+} from '@/lib/chapter-copy'
 
 export interface EpilogueData {
   year: number
@@ -24,11 +29,17 @@ interface EpilogueChapterProps {
   data: EpilogueData | null
   isLoading?: boolean
   onDownload?: () => void
+  activityLevel?: ActivityLevel
 }
 
 type ShareState = 'idle' | 'sharing' | 'shared' | 'copied'
 
-export function EpilogueChapter({ data, isLoading, onDownload }: EpilogueChapterProps) {
+export function EpilogueChapter({
+  data,
+  isLoading,
+  onDownload,
+  activityLevel = 'typical',
+}: EpilogueChapterProps) {
   const [shareState, setShareState] = useState<ShareState>('idle')
   const [isMethodologyOpen, setIsMethodologyOpen] = useState(false)
 
@@ -55,6 +66,8 @@ export function EpilogueChapter({ data, isLoading, onDownload }: EpilogueChapter
   }
 
   const languageColor = getLanguageColor(data.topLanguage)
+  const closingMessage = getEpilogueClosingMessage(activityLevel)
+  const closingContext = getEpilogueClosingContext(activityLevel, data.activeDays)
 
   const shareButtonText = {
     idle: 'Share a Highlight',
@@ -72,16 +85,18 @@ export function EpilogueChapter({ data, isLoading, onDownload }: EpilogueChapter
           'opacity-0 animate-fade-in'
         )}
       >
-        This wasn&apos;t about the numbers.
+        {closingMessage}
       </p>
-      <p
-        className={cn(
-          'text-lead md:text-xl text-text-secondary text-center mt-6 max-w-lg',
-          'opacity-0 animate-fade-in delay-100'
-        )}
-      >
-        It was about showing up — {data.activeDays} times this year. Every commit moved something forward.
-      </p>
+      {closingContext && (
+        <p
+          className={cn(
+            'text-lead md:text-xl text-text-secondary text-center mt-6 max-w-lg',
+            'opacity-0 animate-fade-in delay-100'
+          )}
+        >
+          {closingContext}
+        </p>
+      )}
 
       {/* Share card */}
       <div

--- a/src/components/chapters/your-craft.tsx
+++ b/src/components/chapters/your-craft.tsx
@@ -13,6 +13,13 @@ import {
   ShareButton,
 } from '@/components/ui'
 import { HighlightType, type LanguageHighlight } from '@/lib/highlight-share'
+import { type ActivityLevel } from '@/lib/activity-level'
+import {
+  getCraftSubtitle,
+  getCraftLanguageContext,
+  getCraftTransition,
+  getCraftEmptyDescription,
+} from '@/lib/chapter-copy'
 
 export interface YourCraftData {
   primaryLanguage: string
@@ -26,9 +33,16 @@ interface YourCraftChapterProps {
   isLoading?: boolean
   username?: string
   year?: number
+  activityLevel?: ActivityLevel
 }
 
-export function YourCraftChapter({ data, isLoading, username, year }: YourCraftChapterProps) {
+export function YourCraftChapter({
+  data,
+  isLoading,
+  username,
+  year,
+  activityLevel = 'typical',
+}: YourCraftChapterProps) {
   const languageHighlight: LanguageHighlight | null = data && username && year ? {
     type: HighlightType.Language,
     username,
@@ -50,11 +64,13 @@ export function YourCraftChapter({ data, isLoading, username, year }: YourCraftC
       <Chapter>
         <EmptyState
           title="No language data yet"
-          description="We couldn't find any code contributions for this period. Keep building — your story is just beginning."
+          description={getCraftEmptyDescription(activityLevel)}
         />
       </Chapter>
     )
   }
+
+  const transition = getCraftTransition(activityLevel)
 
   return (
     <Chapter>
@@ -66,8 +82,7 @@ export function YourCraftChapter({ data, isLoading, username, year }: YourCraftC
 
       {/* Contextual subtitle */}
       <ChapterSubtitle>
-        The tools you reached for. The languages that shaped your thinking this
-        year.
+        {getCraftSubtitle(activityLevel)}
       </ChapterSubtitle>
 
       {/* Primary stat callout */}
@@ -80,7 +95,7 @@ export function YourCraftChapter({ data, isLoading, username, year }: YourCraftC
               <span className="text-text-primary font-medium">
                 {data.primaryLanguage}
               </span>{' '}
-              was your primary language this year — the foundation of your work.
+              {getCraftLanguageContext(activityLevel, data.primaryLanguage).replace(`${data.primaryLanguage} `, '')}
             </>
           }
           delay={300}
@@ -113,10 +128,12 @@ export function YourCraftChapter({ data, isLoading, username, year }: YourCraftC
         </div>
       )}
 
-      {/* Transition to next chapter */}
-      <p className="mt-20 text-body-sm text-text-tertiary italic opacity-0 animate-fade-in delay-700">
-        That&apos;s what you built. But you didn&apos;t build it alone.
-      </p>
+      {/* Transition to next chapter - only show for typical/high activity */}
+      {transition && (
+        <p className="mt-20 text-body-sm text-text-tertiary italic opacity-0 animate-fade-in delay-700">
+          {transition}
+        </p>
+      )}
     </Chapter>
   )
 }

--- a/src/lib/activity-level.test.ts
+++ b/src/lib/activity-level.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyActivityLevel,
+  shouldShowMotivationalCopy,
+  isLowActivity,
+  type ActivityMetrics,
+} from './activity-level'
+
+describe('classifyActivityLevel', () => {
+  describe('zero activity', () => {
+    it('returns zero when both contributions and active days are 0', () => {
+      const metrics: ActivityMetrics = { totalContributions: 0, activeDays: 0 }
+      expect(classifyActivityLevel(metrics)).toBe('zero')
+    })
+  })
+
+  describe('sparse activity', () => {
+    it('returns sparse for 1 contribution and 1 active day', () => {
+      const metrics: ActivityMetrics = { totalContributions: 1, activeDays: 1 }
+      expect(classifyActivityLevel(metrics)).toBe('sparse')
+    })
+
+    it('returns sparse for 9 contributions and 4 active days (just under thresholds)', () => {
+      const metrics: ActivityMetrics = { totalContributions: 9, activeDays: 4 }
+      expect(classifyActivityLevel(metrics)).toBe('sparse')
+    })
+
+    it('returns sparse for 5 contributions and 2 active days', () => {
+      const metrics: ActivityMetrics = { totalContributions: 5, activeDays: 2 }
+      expect(classifyActivityLevel(metrics)).toBe('sparse')
+    })
+  })
+
+  describe('typical activity', () => {
+    it('returns typical when contributions meet threshold but active days do not', () => {
+      const metrics: ActivityMetrics = { totalContributions: 10, activeDays: 3 }
+      expect(classifyActivityLevel(metrics)).toBe('typical')
+    })
+
+    it('returns typical when active days meet threshold but contributions do not', () => {
+      const metrics: ActivityMetrics = { totalContributions: 5, activeDays: 5 }
+      expect(classifyActivityLevel(metrics)).toBe('typical')
+    })
+
+    it('returns typical for moderate activity', () => {
+      const metrics: ActivityMetrics = { totalContributions: 100, activeDays: 50 }
+      expect(classifyActivityLevel(metrics)).toBe('typical')
+    })
+
+    it('returns typical for 499 contributions (just under high threshold)', () => {
+      const metrics: ActivityMetrics = { totalContributions: 499, activeDays: 99 }
+      expect(classifyActivityLevel(metrics)).toBe('typical')
+    })
+  })
+
+  describe('high activity', () => {
+    it('returns high for 500+ contributions', () => {
+      const metrics: ActivityMetrics = { totalContributions: 500, activeDays: 50 }
+      expect(classifyActivityLevel(metrics)).toBe('high')
+    })
+
+    it('returns high for 100+ active days', () => {
+      const metrics: ActivityMetrics = { totalContributions: 200, activeDays: 100 }
+      expect(classifyActivityLevel(metrics)).toBe('high')
+    })
+
+    it('returns high for very active users', () => {
+      const metrics: ActivityMetrics = { totalContributions: 1000, activeDays: 200 }
+      expect(classifyActivityLevel(metrics)).toBe('high')
+    })
+
+    it('returns high when either metric meets threshold (contributions)', () => {
+      const metrics: ActivityMetrics = { totalContributions: 600, activeDays: 10 }
+      expect(classifyActivityLevel(metrics)).toBe('high')
+    })
+
+    it('returns high when either metric meets threshold (active days)', () => {
+      const metrics: ActivityMetrics = { totalContributions: 50, activeDays: 150 }
+      expect(classifyActivityLevel(metrics)).toBe('high')
+    })
+  })
+})
+
+describe('shouldShowMotivationalCopy', () => {
+  it('returns false for zero activity', () => {
+    expect(shouldShowMotivationalCopy('zero')).toBe(false)
+  })
+
+  it('returns false for sparse activity', () => {
+    expect(shouldShowMotivationalCopy('sparse')).toBe(false)
+  })
+
+  it('returns true for typical activity', () => {
+    expect(shouldShowMotivationalCopy('typical')).toBe(true)
+  })
+
+  it('returns true for high activity', () => {
+    expect(shouldShowMotivationalCopy('high')).toBe(true)
+  })
+})
+
+describe('isLowActivity', () => {
+  it('returns true for zero activity', () => {
+    expect(isLowActivity('zero')).toBe(true)
+  })
+
+  it('returns true for sparse activity', () => {
+    expect(isLowActivity('sparse')).toBe(true)
+  })
+
+  it('returns false for typical activity', () => {
+    expect(isLowActivity('typical')).toBe(false)
+  })
+
+  it('returns false for high activity', () => {
+    expect(isLowActivity('high')).toBe(false)
+  })
+})

--- a/src/lib/activity-level.ts
+++ b/src/lib/activity-level.ts
@@ -1,0 +1,85 @@
+/**
+ * Activity level classification for conditional copy rendering.
+ *
+ * The goal is to avoid hollow encouragement when data is low.
+ * Copy should feel honest regardless of the numbers.
+ */
+
+export type ActivityLevel = 'zero' | 'sparse' | 'typical' | 'high'
+
+export interface ActivityMetrics {
+  totalContributions: number
+  activeDays: number
+}
+
+/**
+ * Activity level thresholds.
+ *
+ * - Zero: No activity at all
+ * - Sparse: Minimal activity that doesn't warrant celebration
+ * - Typical: Normal activity levels
+ * - High: Above average activity (roughly top 25%)
+ */
+const THRESHOLDS = {
+  // Sparse if below BOTH of these
+  sparseMaxContributions: 10,
+  sparseMaxActiveDays: 5,
+  // High if above EITHER of these
+  highMinContributions: 500,
+  highMinActiveDays: 100,
+} as const
+
+/**
+ * Classifies activity level based on contribution metrics.
+ *
+ * @param metrics - The user's contribution metrics
+ * @returns The activity level classification
+ *
+ * @example
+ * classifyActivityLevel({ totalContributions: 0, activeDays: 0 }) // 'zero'
+ * classifyActivityLevel({ totalContributions: 5, activeDays: 3 }) // 'sparse'
+ * classifyActivityLevel({ totalContributions: 100, activeDays: 50 }) // 'typical'
+ * classifyActivityLevel({ totalContributions: 600, activeDays: 150 }) // 'high'
+ */
+export function classifyActivityLevel(metrics: ActivityMetrics): ActivityLevel {
+  const { totalContributions, activeDays } = metrics
+
+  // Zero: No activity at all
+  if (totalContributions === 0 && activeDays === 0) {
+    return 'zero'
+  }
+
+  // Sparse: Below thresholds for both metrics
+  if (
+    totalContributions < THRESHOLDS.sparseMaxContributions &&
+    activeDays < THRESHOLDS.sparseMaxActiveDays
+  ) {
+    return 'sparse'
+  }
+
+  // High: Above thresholds for either metric
+  if (
+    totalContributions >= THRESHOLDS.highMinContributions ||
+    activeDays >= THRESHOLDS.highMinActiveDays
+  ) {
+    return 'high'
+  }
+
+  // Typical: Everything else
+  return 'typical'
+}
+
+/**
+ * Checks if the activity level warrants motivational copy.
+ * Only typical and high levels should get motivational language.
+ */
+export function shouldShowMotivationalCopy(level: ActivityLevel): boolean {
+  return level === 'typical' || level === 'high'
+}
+
+/**
+ * Checks if the activity level is low enough to require neutral copy only.
+ */
+export function isLowActivity(level: ActivityLevel): boolean {
+  return level === 'zero' || level === 'sparse'
+}

--- a/src/lib/chapter-copy.ts
+++ b/src/lib/chapter-copy.ts
@@ -1,0 +1,232 @@
+/**
+ * Activity-level-aware copy for chapter components.
+ *
+ * The goal is honest, factual copy that doesn't imply progress or momentum
+ * without evidence. Low/zero activity should receive neutral observations,
+ * not hollow encouragement.
+ */
+
+import { type ActivityLevel } from './activity-level'
+
+/**
+ * Copy variants for TheRhythm chapter subtitle.
+ */
+export function getRhythmSubtitle(level: ActivityLevel): string {
+  switch (level) {
+    case 'zero':
+      return 'Your contribution activity for this period.'
+    case 'sparse':
+      return 'Your contribution activity for this period.'
+    case 'typical':
+    case 'high':
+      return 'Code is a practice. These are the days you showed up.'
+  }
+}
+
+/**
+ * Copy variants for TheRhythm active days context.
+ */
+export function getRhythmActiveContext(
+  level: ActivityLevel,
+  consistencyPercentage: number
+): string | null {
+  switch (level) {
+    case 'zero':
+      return null
+    case 'sparse':
+      return `Active on ${consistencyPercentage}% of the year.`
+    case 'typical':
+    case 'high':
+      return `Active on ${consistencyPercentage}% of the year. Consistency compounds.`
+  }
+}
+
+/**
+ * Copy variants for TheRhythm chapter transition.
+ */
+export function getRhythmTransition(level: ActivityLevel): string | null {
+  switch (level) {
+    case 'zero':
+      return null
+    case 'sparse':
+      return null
+    case 'typical':
+    case 'high':
+      return "Showing up is just the start. Let's see what you built."
+  }
+}
+
+/**
+ * Copy variants for YourCraft empty state description.
+ */
+export function getCraftEmptyDescription(_level: ActivityLevel): string {
+  // Always neutral for empty state - no "keep building" encouragement
+  return 'No code contributions found for this period.'
+}
+
+/**
+ * Copy variants for YourCraft subtitle.
+ */
+export function getCraftSubtitle(level: ActivityLevel): string {
+  switch (level) {
+    case 'zero':
+    case 'sparse':
+      return 'The languages used in your contributions.'
+    case 'typical':
+    case 'high':
+      return 'The tools you reached for. The languages that shaped your thinking this year.'
+  }
+}
+
+/**
+ * Copy variants for YourCraft primary language context.
+ */
+export function getCraftLanguageContext(
+  level: ActivityLevel,
+  language: string
+): string {
+  switch (level) {
+    case 'zero':
+    case 'sparse':
+      return `${language} was your most used language.`
+    case 'typical':
+    case 'high':
+      return `${language} was your primary language this year — the foundation of your work.`
+  }
+}
+
+/**
+ * Copy variants for YourCraft chapter transition.
+ */
+export function getCraftTransition(level: ActivityLevel): string | null {
+  switch (level) {
+    case 'zero':
+    case 'sparse':
+      return null
+    case 'typical':
+    case 'high':
+      return "That's what you built. But you didn't build it alone."
+  }
+}
+
+/**
+ * Copy variants for TheCollaboration empty state description.
+ */
+export function getCollaborationEmptyDescription(_level: ActivityLevel): string {
+  // Neutral observation, not "solo work is meaningful work"
+  return 'No collaboration data found for this period.'
+}
+
+/**
+ * Copy variants for TheCollaboration subtitle.
+ */
+export function getCollaborationSubtitle(level: ActivityLevel): string {
+  switch (level) {
+    case 'zero':
+    case 'sparse':
+      return 'Your pull request and collaboration activity.'
+    case 'typical':
+    case 'high':
+      return 'Code is a conversation. These are the people and PRs that shaped your year.'
+  }
+}
+
+/**
+ * Copy variants for TheCollaboration merged PRs context.
+ */
+export function getCollaborationMergedContext(
+  level: ActivityLevel,
+  count: number
+): string {
+  switch (level) {
+    case 'zero':
+    case 'sparse':
+      return `You shipped ${count} pull ${count === 1 ? 'request' : 'requests'} this year.`
+    case 'typical':
+    case 'high':
+      return `You shipped ${count} pull ${count === 1 ? 'request' : 'requests'} this year. Every merge is progress.`
+  }
+}
+
+/**
+ * Copy variants for TheCollaboration chapter transition.
+ */
+export function getCollaborationTransition(level: ActivityLevel): string | null {
+  switch (level) {
+    case 'zero':
+    case 'sparse':
+      return null
+    case 'typical':
+    case 'high':
+      return "Now let's look at when you did your best work."
+  }
+}
+
+/**
+ * Copy variants for PeakMoments empty state description.
+ */
+export function getPeakMomentsEmptyDescription(_level: ActivityLevel): string {
+  // Neutral, not "your peak moments are ahead of you"
+  return 'No peak activity data found for this period.'
+}
+
+/**
+ * Copy variants for PeakMoments subtitle.
+ */
+export function getPeakMomentsSubtitle(level: ActivityLevel): string {
+  switch (level) {
+    case 'zero':
+    case 'sparse':
+      return 'Your most active periods.'
+    case 'typical':
+    case 'high':
+      return 'The days you were in flow. When everything clicked.'
+  }
+}
+
+/**
+ * Copy variants for PeakMoments chapter transition.
+ */
+export function getPeakMomentsTransition(level: ActivityLevel): string | null {
+  switch (level) {
+    case 'zero':
+    case 'sparse':
+      return null
+    case 'typical':
+    case 'high':
+      return "That was your year. Let's bring it all together."
+  }
+}
+
+/**
+ * Copy variants for Epilogue closing message.
+ */
+export function getEpilogueClosingMessage(level: ActivityLevel): string {
+  switch (level) {
+    case 'zero':
+      return 'Your activity for this period.'
+    case 'sparse':
+      return 'Your activity for this period.'
+    case 'typical':
+    case 'high':
+      return "This wasn't about the numbers."
+  }
+}
+
+/**
+ * Copy variants for Epilogue closing context.
+ */
+export function getEpilogueClosingContext(
+  level: ActivityLevel,
+  activeDays: number
+): string | null {
+  switch (level) {
+    case 'zero':
+      return null
+    case 'sparse':
+      return `You were active on ${activeDays} ${activeDays === 1 ? 'day' : 'days'} this year.`
+    case 'typical':
+    case 'high':
+      return `It was about showing up — ${activeDays} times this year. Every commit moved something forward.`
+  }
+}


### PR DESCRIPTION
## Summary

- Add activity level classifier that categorizes users into zero/sparse/typical/high based on contribution metrics
- Create chapter-copy utility with copy variants for each activity level
- Update all 5 chapter components to use activity-level-aware copy
- Remove motivational language ("Consistency compounds", "Every commit moved something forward") for zero/sparse activity
- Update empty state descriptions to be neutral rather than encouraging

## Activity Level Thresholds

| Level | Criteria | Copy Approach |
|-------|----------|---------------|
| Zero | 0 contributions AND 0 active days | Factual acknowledgment only |
| Sparse | <10 contributions AND <5 active days | Neutral observation |
| Typical | Normal activity | Current copy (unchanged) |
| High | 500+ contributions OR 100+ active days | Light reflection (unchanged) |

## Key Changes

**New files:**
- `src/lib/activity-level.ts` - Activity level classifier
- `src/lib/activity-level.test.ts` - Tests for classifier (21 tests)
- `src/lib/chapter-copy.ts` - Copy variants for all chapters

**Modified chapters:**
- Prologue: No changes needed (already factual)
- The Rhythm: Removed "Consistency compounds" for low activity
- Your Craft: Neutral empty state, removed "foundation of your work"
- The Collaboration: Removed "Every merge is progress" for low activity
- Peak Moments: Neutral time-of-day descriptions for low activity
- Epilogue: Neutral closing message for low activity

## Test plan

- [x] All 254 existing tests pass
- [x] New activity-level tests pass (21 tests)
- [x] ESLint passes
- [x] TypeScript type check passes
- [ ] Manual verification: View rewind for user with low/zero contributions

Fixes #8