### PR TITLE
feat: Add same-period Year-over-Year comparison

### DIFF
--- a/src/lib/comparisons.test.ts
+++ b/src/lib/comparisons.test.ts
@@ -1,20 +1,29 @@
 import { describe, it, expect } from 'vitest'
 import { compareYears } from './comparisons'
-import type { YearStats } from './github'
+import type { YearStats, ContributionDay } from './github'
 
 describe('compareYears', () => {
+  const createDay = (date: string, count: number): ContributionDay => ({
+    date,
+    contributionCount: count,
+    contributionLevel: count > 0 ? 'FIRST_QUARTILE' : 'NONE',
+  })
+
   const createMinimalStats = (
     overrides: Partial<{
+      year: number
       totalContributions: number
       activeDays: number
+      totalDays: number
       longestStreak: number
       pullRequestsMerged: number
       primaryLanguage: string
       languages: { name: string; percentage: number; color: string }[]
+      contributionCalendar: ContributionDay[]
     }> = {}
   ): YearStats => ({
     user: { username: 'testuser', name: 'Test', avatarUrl: 'url' },
-    year: 2024,
+    year: overrides.year ?? 2024,
     totalContributions: overrides.totalContributions ?? 100,
     dataCompleteness: {
       restrictedContributions: 0,
@@ -29,12 +38,13 @@ describe('compareYears', () => {
     },
     rhythm: {
       activeDays: overrides.activeDays ?? 200,
-      totalDays: 365,
+      totalDays: overrides.totalDays ?? 365,
       longestStreak: overrides.longestStreak ?? 10,
       currentStreak: 5,
       busiestMonth: 'March',
       busiestMonthCount: 50,
       contributionsByMonth: [],
+      contributionCalendar: overrides.contributionCalendar ?? [],
     },
     craft: {
       primaryLanguage: overrides.primaryLanguage ?? 'TypeScript',
@@ -65,118 +75,290 @@ describe('compareYears', () => {
     },
   })
 
-  it('calculates positive contribution delta', () => {
-    const current = createMinimalStats({ totalContributions: 200 })
-    const previous = createMinimalStats({ totalContributions: 100 })
+  describe('full-year comparison (365 days)', () => {
+    it('calculates positive contribution delta', () => {
+      const current = createMinimalStats({ totalContributions: 200, totalDays: 365 })
+      const previous = createMinimalStats({ totalContributions: 100 })
 
-    const result = compareYears(current, previous)
+      const result = compareYears(current, previous)
 
-    expect(result.contributionsDelta).toBe(100)
-    expect(result.contributionsPercentChange).toBe(100)
-  })
-
-  it('calculates negative contribution delta', () => {
-    const current = createMinimalStats({ totalContributions: 80 })
-    const previous = createMinimalStats({ totalContributions: 100 })
-
-    const result = compareYears(current, previous)
-
-    expect(result.contributionsDelta).toBe(-20)
-    expect(result.contributionsPercentChange).toBe(-20)
-  })
-
-  it('handles zero previous contributions gracefully', () => {
-    const current = createMinimalStats({ totalContributions: 100 })
-    const previous = createMinimalStats({ totalContributions: 0 })
-
-    const result = compareYears(current, previous)
-
-    expect(result.contributionsDelta).toBe(100)
-    expect(result.contributionsPercentChange).toBe(0)
-  })
-
-  it('calculates active days delta', () => {
-    const current = createMinimalStats({ activeDays: 250 })
-    const previous = createMinimalStats({ activeDays: 200 })
-
-    const result = compareYears(current, previous)
-
-    expect(result.activeDaysDelta).toBe(50)
-  })
-
-  it('calculates streak delta', () => {
-    const current = createMinimalStats({ longestStreak: 30 })
-    const previous = createMinimalStats({ longestStreak: 15 })
-
-    const result = compareYears(current, previous)
-
-    expect(result.longestStreakDelta).toBe(15)
-  })
-
-  it('calculates PR delta', () => {
-    const current = createMinimalStats({ pullRequestsMerged: 25 })
-    const previous = createMinimalStats({ pullRequestsMerged: 10 })
-
-    const result = compareYears(current, previous)
-
-    expect(result.pullRequestsDelta).toBe(15)
-  })
-
-  it('identifies new languages', () => {
-    const current = createMinimalStats({
-      languages: [
-        { name: 'TypeScript', percentage: 50, color: '#3178C6' },
-        { name: 'Rust', percentage: 30, color: '#DEA584' },
-      ],
-    })
-    const previous = createMinimalStats({
-      languages: [{ name: 'TypeScript', percentage: 100, color: '#3178C6' }],
+      expect(result.contributionsDelta).toBe(100)
+      expect(result.contributionsPercentChange).toBe(100)
+      expect(result.comparisonType).toBe('full-year')
     })
 
-    const result = compareYears(current, previous)
+    it('calculates negative contribution delta', () => {
+      const current = createMinimalStats({ totalContributions: 80, totalDays: 365 })
+      const previous = createMinimalStats({ totalContributions: 100 })
 
-    expect(result.newLanguages).toContain('Rust')
-    expect(result.newLanguages).not.toContain('TypeScript')
-  })
+      const result = compareYears(current, previous)
 
-  it('identifies dropped languages', () => {
-    const current = createMinimalStats({
-      languages: [{ name: 'TypeScript', percentage: 100, color: '#3178C6' }],
-    })
-    const previous = createMinimalStats({
-      languages: [
-        { name: 'TypeScript', percentage: 50, color: '#3178C6' },
-        { name: 'Python', percentage: 50, color: '#3776AB' },
-      ],
+      expect(result.contributionsDelta).toBe(-20)
+      expect(result.contributionsPercentChange).toBe(-20)
     })
 
-    const result = compareYears(current, previous)
+    it('handles zero previous contributions gracefully', () => {
+      const current = createMinimalStats({ totalContributions: 100, totalDays: 365 })
+      const previous = createMinimalStats({ totalContributions: 0 })
 
-    expect(result.droppedLanguages).toContain('Python')
-    expect(result.droppedLanguages).not.toContain('TypeScript')
+      const result = compareYears(current, previous)
+
+      expect(result.contributionsDelta).toBe(100)
+      expect(result.contributionsPercentChange).toBe(0)
+    })
+
+    it('calculates active days delta', () => {
+      const current = createMinimalStats({ activeDays: 250, totalDays: 365 })
+      const previous = createMinimalStats({ activeDays: 200 })
+
+      const result = compareYears(current, previous)
+
+      expect(result.activeDaysDelta).toBe(50)
+    })
+
+    it('calculates streak delta', () => {
+      const current = createMinimalStats({ longestStreak: 30, totalDays: 365 })
+      const previous = createMinimalStats({ longestStreak: 15 })
+
+      const result = compareYears(current, previous)
+
+      expect(result.longestStreakDelta).toBe(15)
+    })
+
+    it('calculates PR delta', () => {
+      const current = createMinimalStats({ pullRequestsMerged: 25, totalDays: 365 })
+      const previous = createMinimalStats({ pullRequestsMerged: 10 })
+
+      const result = compareYears(current, previous)
+
+      expect(result.pullRequestsDelta).toBe(15)
+    })
+
+    it('identifies new languages', () => {
+      const current = createMinimalStats({
+        totalDays: 365,
+        languages: [
+          { name: 'TypeScript', percentage: 50, color: '#3178C6' },
+          { name: 'Rust', percentage: 30, color: '#DEA584' },
+        ],
+      })
+      const previous = createMinimalStats({
+        languages: [{ name: 'TypeScript', percentage: 100, color: '#3178C6' }],
+      })
+
+      const result = compareYears(current, previous)
+
+      expect(result.newLanguages).toContain('Rust')
+      expect(result.newLanguages).not.toContain('TypeScript')
+    })
+
+    it('identifies dropped languages', () => {
+      const current = createMinimalStats({
+        totalDays: 365,
+        languages: [{ name: 'TypeScript', percentage: 100, color: '#3178C6' }],
+      })
+      const previous = createMinimalStats({
+        languages: [
+          { name: 'TypeScript', percentage: 50, color: '#3178C6' },
+          { name: 'Python', percentage: 50, color: '#3776AB' },
+        ],
+      })
+
+      const result = compareYears(current, previous)
+
+      expect(result.droppedLanguages).toContain('Python')
+      expect(result.droppedLanguages).not.toContain('TypeScript')
+    })
+
+    it('detects consistency improvement', () => {
+      const current = createMinimalStats({ activeDays: 300, totalDays: 365 })
+      const previous = createMinimalStats({ activeDays: 200 })
+
+      const result = compareYears(current, previous)
+
+      expect(result.consistencyImproved).toBe(true)
+    })
+
+    it('detects consistency decline', () => {
+      const current = createMinimalStats({ activeDays: 150, totalDays: 365 })
+      const previous = createMinimalStats({ activeDays: 250 })
+
+      const result = compareYears(current, previous)
+
+      expect(result.consistencyImproved).toBe(false)
+    })
   })
 
-  it('detects consistency improvement', () => {
-    const current = createMinimalStats({ activeDays: 300 })
-    const previous = createMinimalStats({ activeDays: 200 })
+  describe('same-period comparison (partial year)', () => {
+    it('uses same-period comparison when current year has fewer than 350 days', () => {
+      // Create 30 days of data for 2026
+      const currentCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 30; i++) {
+        currentCalendar.push(createDay(`2026-01-${i.toString().padStart(2, '0')}`, 10))
+      }
 
-    const result = compareYears(current, previous)
+      // Create 365 days for 2025 (30 contributions per day in Jan)
+      const previousCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 31; i++) {
+        previousCalendar.push(createDay(`2025-01-${i.toString().padStart(2, '0')}`, 5))
+      }
+      for (let i = 1; i <= 334; i++) {
+        previousCalendar.push(createDay(`2025-02-${(i % 28 + 1).toString().padStart(2, '0')}`, 1))
+      }
 
-    expect(result.consistencyImproved).toBe(true)
+      const current = createMinimalStats({
+        year: 2026,
+        totalContributions: 300, // 30 days * 10
+        totalDays: 30,
+        contributionCalendar: currentCalendar,
+      })
+      const previous = createMinimalStats({
+        year: 2025,
+        totalContributions: 500, // Total for year
+        totalDays: 365,
+        contributionCalendar: previousCalendar,
+      })
+
+      const result = compareYears(current, previous)
+
+      expect(result.comparisonType).toBe('same-period')
+      expect(result.periodDays).toBe(30)
+      expect(result.previousYearTotal).toBe(500)
+      // Same period contributions should be calculated from Jan 1-30 of 2025
+      expect(result.samePeriodPreviousContributions).toBe(150) // 30 days * 5
+    })
+
+    it('compares against same period of previous year, not total', () => {
+      // 10 days in 2026 with 20 contributions per day = 200 total
+      const currentCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 10; i++) {
+        currentCalendar.push(createDay(`2026-01-${i.toString().padStart(2, '0')}`, 20))
+      }
+
+      // Create valid dates for 2025 - first 10 days have 10 contributions each
+      // Rest of year has 1 contribution each
+      const previousCalendar: ContributionDay[] = []
+      // January 1-10: 10 contributions each
+      for (let i = 1; i <= 10; i++) {
+        previousCalendar.push(createDay(`2025-01-${i.toString().padStart(2, '0')}`, 10))
+      }
+      // January 11-31: 1 contribution each (21 days)
+      for (let i = 11; i <= 31; i++) {
+        previousCalendar.push(createDay(`2025-01-${i.toString().padStart(2, '0')}`, 1))
+      }
+      // February 1-28: 1 contribution each
+      for (let i = 1; i <= 28; i++) {
+        previousCalendar.push(createDay(`2025-02-${i.toString().padStart(2, '0')}`, 1))
+      }
+      // March through December (for simplicity, just add enough to get 365 days total)
+      // Already have 31 + 28 = 59 days, need 306 more
+      const months = ['03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
+      const daysInMonth = [31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+      for (let m = 0; m < months.length; m++) {
+        for (let d = 1; d <= daysInMonth[m]; d++) {
+          previousCalendar.push(createDay(`2025-${months[m]}-${d.toString().padStart(2, '0')}`, 1))
+        }
+      }
+
+      const current = createMinimalStats({
+        year: 2026,
+        totalContributions: 200,
+        totalDays: 10,
+        contributionCalendar: currentCalendar,
+      })
+      const previous = createMinimalStats({
+        year: 2025,
+        totalContributions: 455, // Total for year
+        totalDays: 365,
+        contributionCalendar: previousCalendar,
+      })
+
+      const result = compareYears(current, previous)
+
+      // Should compare 200 (current 10 days) vs 100 (first 10 days of 2025)
+      expect(result.contributionsDelta).toBe(100) // 200 - 100
+      expect(result.contributionsPercentChange).toBe(100) // 100% increase
+      expect(result.samePeriodPreviousContributions).toBe(100)
+    })
+
+    it('calculates projection after 7 days', () => {
+      const currentCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 10; i++) {
+        currentCalendar.push(createDay(`2026-01-${i.toString().padStart(2, '0')}`, 10))
+      }
+
+      const current = createMinimalStats({
+        year: 2026,
+        totalContributions: 100, // 10 days * 10
+        totalDays: 10,
+        contributionCalendar: currentCalendar,
+      })
+      const previous = createMinimalStats({
+        year: 2025,
+        totalContributions: 500,
+        totalDays: 365,
+        contributionCalendar: [],
+      })
+
+      const result = compareYears(current, previous)
+
+      // Projection: (100 / 10) * 365 = 3650
+      expect(result.projectedYearTotal).toBe(3650)
+    })
+
+    it('does not show projection before 7 days', () => {
+      const currentCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 5; i++) {
+        currentCalendar.push(createDay(`2026-01-${i.toString().padStart(2, '0')}`, 10))
+      }
+
+      const current = createMinimalStats({
+        year: 2026,
+        totalContributions: 50,
+        totalDays: 5,
+        contributionCalendar: currentCalendar,
+      })
+      const previous = createMinimalStats({
+        year: 2025,
+        totalContributions: 500,
+        totalDays: 365,
+        contributionCalendar: [],
+      })
+
+      const result = compareYears(current, previous)
+
+      expect(result.projectedYearTotal).toBeUndefined()
+    })
+
+    it('handles no data for same period last year', () => {
+      const currentCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 10; i++) {
+        currentCalendar.push(createDay(`2026-01-${i.toString().padStart(2, '0')}`, 10))
+      }
+
+      const current = createMinimalStats({
+        year: 2026,
+        totalContributions: 100,
+        totalDays: 10,
+        contributionCalendar: currentCalendar,
+      })
+      const previous = createMinimalStats({
+        year: 2025,
+        totalContributions: 0,
+        totalDays: 365,
+        contributionCalendar: [], // No calendar data
+      })
+
+      const result = compareYears(current, previous)
+
+      expect(result.samePeriodPreviousContributions).toBe(0)
+      expect(result.contributionsPercentChange).toBe(0) // No division by zero
+    })
   })
 
-  it('detects consistency decline', () => {
-    const current = createMinimalStats({ activeDays: 150 })
-    const previous = createMinimalStats({ activeDays: 250 })
-
-    const result = compareYears(current, previous)
-
-    expect(result.consistencyImproved).toBe(false)
-  })
-
-  describe('narrativeInsights', () => {
+  describe('narrativeInsights for full-year', () => {
     it('generates positive contribution insight', () => {
-      const current = createMinimalStats({ totalContributions: 150 })
+      const current = createMinimalStats({ totalContributions: 150, totalDays: 365 })
       const previous = createMinimalStats({ totalContributions: 100 })
 
       const result = compareYears(current, previous)
@@ -185,7 +367,7 @@ describe('compareYears', () => {
     })
 
     it('generates negative contribution insight with positive framing', () => {
-      const current = createMinimalStats({ totalContributions: 80 })
+      const current = createMinimalStats({ totalContributions: 80, totalDays: 365 })
       const previous = createMinimalStats({ totalContributions: 100 })
 
       const result = compareYears(current, previous)
@@ -194,7 +376,7 @@ describe('compareYears', () => {
     })
 
     it('generates streak improvement insight when delta exceeds threshold', () => {
-      const current = createMinimalStats({ longestStreak: 20 })
+      const current = createMinimalStats({ longestStreak: 20, totalDays: 365 })
       const previous = createMinimalStats({ longestStreak: 10 })
 
       const result = compareYears(current, previous)
@@ -204,6 +386,7 @@ describe('compareYears', () => {
 
     it('generates new language insight for single language', () => {
       const current = createMinimalStats({
+        totalDays: 365,
         languages: [
           { name: 'TypeScript', percentage: 50, color: '#3178C6' },
           { name: 'Go', percentage: 50, color: '#00ADD8' },
@@ -220,6 +403,7 @@ describe('compareYears', () => {
 
     it('generates new languages insight for multiple languages', () => {
       const current = createMinimalStats({
+        totalDays: 365,
         languages: [
           { name: 'TypeScript', percentage: 40, color: '#3178C6' },
           { name: 'Go', percentage: 30, color: '#00ADD8' },
@@ -236,7 +420,7 @@ describe('compareYears', () => {
     })
 
     it('generates PR insight when delta exceeds threshold', () => {
-      const current = createMinimalStats({ pullRequestsMerged: 20 })
+      const current = createMinimalStats({ pullRequestsMerged: 20, totalDays: 365 })
       const previous = createMinimalStats({ pullRequestsMerged: 10 })
 
       const result = compareYears(current, previous)
@@ -245,7 +429,7 @@ describe('compareYears', () => {
     })
 
     it('generates primary language change insight', () => {
-      const current = createMinimalStats({ primaryLanguage: 'Rust' })
+      const current = createMinimalStats({ primaryLanguage: 'Rust', totalDays: 365 })
       const previous = createMinimalStats({ primaryLanguage: 'TypeScript' })
 
       const result = compareYears(current, previous)
@@ -256,16 +440,169 @@ describe('compareYears', () => {
     })
 
     it('generates consistency insight when consistency improved even with small delta', () => {
-      // 153 active days this year (41.9% consistency)
-      // 150 active days last year (41.1% consistency)
-      // Delta is only 3 days (below threshold of 5), but consistency DID improve
-      const current = createMinimalStats({ activeDays: 153 })
+      const current = createMinimalStats({ activeDays: 153, totalDays: 365 })
       const previous = createMinimalStats({ activeDays: 150 })
 
       const result = compareYears(current, previous)
 
       expect(result.consistencyImproved).toBe(true)
       expect(result.narrativeInsights.some((i) => i.includes('more consistent'))).toBe(true)
+    })
+  })
+
+  describe('narrativeInsights for same-period (adaptive messaging)', () => {
+    it('generates Day 1 message for single day', () => {
+      const currentCalendar = [createDay('2026-01-01', 32)]
+
+      const previousCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 365; i++) {
+        previousCalendar.push(createDay(`2025-01-${((i % 28) + 1).toString().padStart(2, '0')}`, 0))
+      }
+
+      const current = createMinimalStats({
+        year: 2026,
+        totalContributions: 32,
+        totalDays: 1,
+        contributionCalendar: currentCalendar,
+      })
+      const previous = createMinimalStats({
+        year: 2025,
+        totalContributions: 40,
+        totalDays: 365,
+        contributionCalendar: previousCalendar,
+      })
+
+      const result = compareYears(current, previous)
+
+      expect(result.narrativeInsights.some((i) => i.includes('Day 1 of 2026'))).toBe(true)
+      expect(result.narrativeInsights.some((i) => i.includes('32 contributions'))).toBe(true)
+    })
+
+    it('generates Q1 message with trajectory (days 31-90)', () => {
+      const currentCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 60; i++) {
+        currentCalendar.push(createDay(`2026-01-${((i % 28) + 1).toString().padStart(2, '0')}`, 31))
+      }
+
+      const previousCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 365; i++) {
+        previousCalendar.push(createDay(`2025-01-${((i % 28) + 1).toString().padStart(2, '0')}`, 0))
+      }
+
+      const current = createMinimalStats({
+        year: 2026,
+        totalContributions: 1860, // 60 * 31
+        totalDays: 60,
+        contributionCalendar: currentCalendar,
+      })
+      const previous = createMinimalStats({
+        year: 2025,
+        totalContributions: 12,
+        totalDays: 365,
+        contributionCalendar: previousCalendar,
+      })
+
+      const result = compareYears(current, previous)
+
+      expect(result.narrativeInsights.some((i) => i.includes('Through'))).toBe(true)
+      expect(result.narrativeInsights.some((i) => i.includes('contributions'))).toBe(true)
+    })
+
+    it('generates Q2 message comparing to last year total (days 91-180)', () => {
+      const currentCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 120; i++) {
+        const month = Math.floor((i - 1) / 30) + 1
+        const day = ((i - 1) % 30) + 1
+        currentCalendar.push(createDay(`2026-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`, 36))
+      }
+
+      const previousCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 365; i++) {
+        previousCalendar.push(createDay(`2025-01-${((i % 28) + 1).toString().padStart(2, '0')}`, 0))
+      }
+
+      const current = createMinimalStats({
+        year: 2026,
+        totalContributions: 4320, // Exceeds last year total
+        totalDays: 120,
+        contributionCalendar: currentCalendar,
+      })
+      const previous = createMinimalStats({
+        year: 2025,
+        totalContributions: 40, // Low total last year
+        totalDays: 365,
+        contributionCalendar: previousCalendar,
+      })
+
+      const result = compareYears(current, previous)
+
+      expect(result.narrativeInsights.some((i) => i.includes('Through'))).toBe(true)
+    })
+
+    it('generates Q3 message with pace comparison (days 181-270)', () => {
+      const currentCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 200; i++) {
+        const month = Math.floor((i - 1) / 30) + 1
+        const day = ((i - 1) % 30) + 1
+        currentCalendar.push(createDay(`2026-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`, 42))
+      }
+
+      const previousCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 365; i++) {
+        const month = Math.floor((i - 1) / 30) + 1
+        const day = ((i - 1) % 30) + 1
+        previousCalendar.push(createDay(`2025-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`, 1))
+      }
+
+      const current = createMinimalStats({
+        year: 2026,
+        totalContributions: 8400,
+        totalDays: 200,
+        contributionCalendar: currentCalendar,
+      })
+      const previous = createMinimalStats({
+        year: 2025,
+        totalContributions: 365,
+        totalDays: 365,
+        contributionCalendar: previousCalendar,
+      })
+
+      const result = compareYears(current, previous)
+
+      expect(result.narrativeInsights.some((i) => i.includes('At this point'))).toBe(true)
+    })
+
+    it('generates Q4 message with reliable projection (days 271-365)', () => {
+      const currentCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 310; i++) {
+        const month = Math.floor((i - 1) / 30) + 1
+        const day = ((i - 1) % 30) + 1
+        currentCalendar.push(createDay(`2026-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`, 42))
+      }
+
+      const previousCalendar: ContributionDay[] = []
+      for (let i = 1; i <= 365; i++) {
+        const month = Math.floor((i - 1) / 30) + 1
+        const day = ((i - 1) % 30) + 1
+        previousCalendar.push(createDay(`2025-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`, 1))
+      }
+
+      const current = createMinimalStats({
+        year: 2026,
+        totalContributions: 13020,
+        totalDays: 310,
+        contributionCalendar: currentCalendar,
+      })
+      const previous = createMinimalStats({
+        year: 2025,
+        totalContributions: 365,
+        totalDays: 365,
+        contributionCalendar: previousCalendar,
+      })
+
+      const result = compareYears(current, previous)
+
+      expect(result.narrativeInsights.some((i) => i.includes('% of the year complete'))).toBe(true)
     })
   })
 })

--- a/src/lib/comparisons.ts
+++ b/src/lib/comparisons.ts
@@ -1,13 +1,19 @@
 /**
- * Year-over-year comparison utilities
+ * Year-over-year comparison utilities with same-period comparison for partial years
  */
 
-import type { YearStats } from './github'
+import type { YearStats, ContributionDay } from './github'
 
 // Thresholds for generating narrative insights
 const ACTIVE_DAYS_DELTA_THRESHOLD = 5
 const STREAK_DELTA_THRESHOLD = 3
 const PR_DELTA_THRESHOLD = 3
+
+// Minimum days before showing projections (to avoid wild swings)
+const MIN_DAYS_FOR_PROJECTION = 7
+
+// Full year threshold (if current year has fewer than this many days, use same-period comparison)
+const FULL_YEAR_THRESHOLD = 350
 
 export interface YearComparison {
   contributionsDelta: number
@@ -19,19 +25,289 @@ export interface YearComparison {
   droppedLanguages: string[]
   consistencyImproved: boolean
   narrativeInsights: string[]
+  // Same-period comparison fields
+  comparisonType: 'full-year' | 'same-period'
+  periodDays?: number
+  samePeriodPreviousContributions?: number
+  projectedYearTotal?: number
+  previousYearTotal?: number
+}
+
+/**
+ * Parse a date string to get year, month, day in UTC
+ * GitHub dates are in YYYY-MM-DD format
+ */
+function parseDateString(dateStr: string): { year: number; month: number; day: number } {
+  const parts = dateStr.split('-')
+  return {
+    year: parseInt(parts[0], 10),
+    month: parseInt(parts[1], 10),
+    day: parseInt(parts[2], 10),
+  }
+}
+
+/**
+ * Calculate day of year (1-365/366) from a date string
+ * Using direct calculation to avoid timezone issues
+ */
+function getDayOfYear(dateStr: string): number {
+  const { year, month, day } = parseDateString(dateStr)
+
+  // Days in each month (non-leap year)
+  const daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+  // Adjust for leap year
+  const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0)
+  if (isLeapYear) {
+    daysInMonth[1] = 29
+  }
+
+  // Sum days from previous months + current day
+  let dayOfYear = day
+  for (let m = 0; m < month - 1; m++) {
+    dayOfYear += daysInMonth[m]
+  }
+
+  return dayOfYear
+}
+
+/**
+ * Get total contributions for a specific date range (Jan 1 to cutoff date)
+ */
+function getSamePeriodContributions(
+  calendar: ContributionDay[],
+  year: number,
+  cutoffDayOfYear: number
+): number {
+  let total = 0
+  for (const day of calendar) {
+    const { year: dayYear } = parseDateString(day.date)
+    if (dayYear === year && getDayOfYear(day.date) <= cutoffDayOfYear) {
+      total += day.contributionCount
+    }
+  }
+  return total
+}
+
+/**
+ * Calculate projected year total based on current pace
+ */
+function calculateProjection(currentContributions: number, daysSoFar: number): number {
+  if (daysSoFar < MIN_DAYS_FOR_PROJECTION) {
+    return 0
+  }
+  return Math.round((currentContributions / daysSoFar) * 365)
+}
+
+/**
+ * Format a number with thousands separators
+ */
+function formatNumber(num: number): string {
+  return num.toLocaleString()
+}
+
+/**
+ * Get month and day from day of year (1-based)
+ */
+function getMonthAndDayFromDayOfYear(dayOfYear: number, year: number): { month: number; day: number } {
+  const daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+  // Adjust for leap year
+  const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0)
+  if (isLeapYear) {
+    daysInMonth[1] = 29
+  }
+
+  let remaining = dayOfYear
+  let month = 0
+  while (month < 12 && remaining > daysInMonth[month]) {
+    remaining -= daysInMonth[month]
+    month++
+  }
+
+  return { month: month + 1, day: remaining }
+}
+
+/**
+ * Get the period label based on day of year
+ */
+function getPeriodLabel(dayOfYear: number, year: number): string {
+  if (dayOfYear === 1) {
+    return `Day 1 of ${year}`
+  }
+  if (dayOfYear <= 30) {
+    return `First ${dayOfYear} days of ${year}`
+  }
+
+  const monthNames = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December'
+  ]
+
+  const { month, day } = getMonthAndDayFromDayOfYear(dayOfYear, year)
+  const monthName = monthNames[month - 1]
+
+  if (dayOfYear <= 90) {
+    return `Through ${monthName} ${day}`
+  }
+  if (dayOfYear <= 180) {
+    return `Through ${monthName}`
+  }
+  if (dayOfYear <= 270) {
+    return `At this point in ${year}`
+  }
+
+  const percentComplete = Math.round((dayOfYear / 365) * 100)
+  return `With ${percentComplete}% of the year complete`
+}
+
+/**
+ * Generate narrative insights for same-period comparison
+ */
+function generateSamePeriodInsights(
+  currentContributions: number,
+  previousSamePeriodContributions: number,
+  previousYearTotal: number,
+  projectedTotal: number,
+  dayOfYear: number,
+  currentYear: number,
+  previousYear: number
+): string[] {
+  const insights: string[] = []
+  const periodLabel = getPeriodLabel(dayOfYear, currentYear)
+
+  // Early year (Days 1-30): Focus on immediate comparison
+  if (dayOfYear <= 30) {
+    const sameDayLabel = dayOfYear === 1 ? 'Same day last year' : `Same period last year`
+    insights.push(
+      `${periodLabel}: ${formatNumber(currentContributions)} contributions. ${sameDayLabel}: ${formatNumber(previousSamePeriodContributions)}.`
+    )
+
+    if (dayOfYear >= MIN_DAYS_FOR_PROJECTION && projectedTotal > 0) {
+      const dailyAvg = Math.round(currentContributions / dayOfYear)
+      insights.push(`At ${dailyAvg}/day, you're on pace for ${formatNumber(projectedTotal)} this year.`)
+    }
+  }
+  // Q1 (Days 31-90): Show trajectory
+  else if (dayOfYear <= 90) {
+    insights.push(
+      `${periodLabel}: ${formatNumber(currentContributions)} contributions (vs ${formatNumber(previousSamePeriodContributions)} same period last year).`
+    )
+
+    if (projectedTotal > 0) {
+      if (projectedTotal > previousYearTotal * 1.5) {
+        insights.push(`You're on track to exceed ${previousYear}'s total by ${Math.round((projectedTotal / previousYearTotal - 1) * 100)}%.`)
+      } else if (projectedTotal > previousYearTotal) {
+        insights.push(`On pace to beat last year's ${formatNumber(previousYearTotal)} contributions.`)
+      }
+    }
+  }
+  // Q2 (Days 91-180): Compare to last year's total
+  else if (dayOfYear <= 180) {
+    insights.push(`${periodLabel}: ${formatNumber(currentContributions)} contributions.`)
+
+    if (currentContributions > previousYearTotal) {
+      const multiplier = previousYearTotal > 0
+        ? Math.round(currentContributions / previousYearTotal * 10) / 10
+        : 0
+      if (multiplier >= 2) {
+        insights.push(`You've already exceeded last year's total (${formatNumber(previousYearTotal)}) by ${multiplier}x.`)
+      } else {
+        insights.push(`You've already exceeded last year's total of ${formatNumber(previousYearTotal)}.`)
+      }
+    } else if (projectedTotal > previousYearTotal) {
+      insights.push(`On pace to beat last year's ${formatNumber(previousYearTotal)} by year end.`)
+    }
+  }
+  // Q3 (Days 181-270): Pace comparison
+  else if (dayOfYear <= 270) {
+    insights.push(
+      `${periodLabel}, you had ${formatNumber(previousSamePeriodContributions)} contributions. This year: ${formatNumber(currentContributions)}.`
+    )
+
+    if (currentContributions > previousSamePeriodContributions) {
+      const paceIncrease = previousSamePeriodContributions > 0
+        ? Math.round((currentContributions / previousSamePeriodContributions - 1) * 100)
+        : 0
+      if (paceIncrease > 0) {
+        insights.push(`You're ${paceIncrease}% ahead of last year's pace.`)
+      }
+    }
+  }
+  // Q4 (Days 271-365): Final stretch, reliable projections
+  else {
+    insights.push(`${periodLabel}: ${formatNumber(currentContributions)} contributions.`)
+
+    if (projectedTotal > 0) {
+      insights.push(`On track to finish with approximately ${formatNumber(projectedTotal)} contributions.`)
+    }
+
+    if (currentContributions > previousSamePeriodContributions) {
+      const delta = currentContributions - previousSamePeriodContributions
+      insights.push(`${formatNumber(delta)} more than same point last year.`)
+    }
+  }
+
+  return insights
 }
 
 /**
  * Compare two years of stats and generate meaningful insights
+ * Automatically uses same-period comparison for partial years
  */
 export function compareYears(
   current: YearStats,
   previous: YearStats
 ): YearComparison {
-  const contributionsDelta = current.totalContributions - previous.totalContributions
-  const contributionsPercentChange = previous.totalContributions > 0
-    ? Math.round((contributionsDelta / previous.totalContributions) * 100)
-    : 0
+  const currentCalendar = current.rhythm.contributionCalendar || []
+  const previousCalendar = previous.rhythm.contributionCalendar || []
+
+  // Determine if we need same-period comparison
+  const currentTotalDays = current.rhythm.totalDays
+  const needsSamePeriodComparison = currentTotalDays < FULL_YEAR_THRESHOLD
+
+  let contributionsDelta: number
+  let contributionsPercentChange: number
+  let comparisonType: 'full-year' | 'same-period'
+  let periodDays: number | undefined
+  let samePeriodPreviousContributions: number | undefined
+  let projectedYearTotal: number | undefined
+  let previousYearTotal: number | undefined
+
+  if (needsSamePeriodComparison && currentCalendar.length > 0) {
+    // Same-period comparison for partial years
+    comparisonType = 'same-period'
+    periodDays = currentTotalDays
+    previousYearTotal = previous.totalContributions
+
+    // Get the day of year for the latest date in current year
+    const dayOfYear = currentTotalDays
+
+    // Get same-period contributions from previous year
+    samePeriodPreviousContributions = getSamePeriodContributions(
+      previousCalendar,
+      previous.year,
+      dayOfYear
+    )
+
+    // Calculate projection if we have enough days
+    if (currentTotalDays >= MIN_DAYS_FOR_PROJECTION) {
+      projectedYearTotal = calculateProjection(current.totalContributions, currentTotalDays)
+    }
+
+    // Calculate delta against same period
+    contributionsDelta = current.totalContributions - samePeriodPreviousContributions
+    contributionsPercentChange = samePeriodPreviousContributions > 0
+      ? Math.round((contributionsDelta / samePeriodPreviousContributions) * 100)
+      : 0
+  } else {
+    // Full-year comparison
+    comparisonType = 'full-year'
+    contributionsDelta = current.totalContributions - previous.totalContributions
+    contributionsPercentChange = previous.totalContributions > 0
+      ? Math.round((contributionsDelta / previous.totalContributions) * 100)
+      : 0
+  }
 
   const activeDaysDelta = current.rhythm.activeDays - previous.rhythm.activeDays
   const longestStreakDelta = current.rhythm.longestStreak - previous.rhythm.longestStreak
@@ -54,24 +330,41 @@ export function compareYears(
   // Generate narrative insights
   const narrativeInsights: string[] = []
 
-  // Always show contribution comparison (the most meaningful stat)
-  if (contributionsPercentChange > 0) {
-    narrativeInsights.push(`You contributed ${contributionsPercentChange}% more than last year.`)
-  } else if (contributionsPercentChange < 0) {
-    narrativeInsights.push(`You contributed ${Math.abs(contributionsPercentChange)}% less than last year — quality over quantity.`)
+  if (comparisonType === 'same-period' && periodDays !== undefined) {
+    // Same-period insights
+    const samePeriodInsights = generateSamePeriodInsights(
+      current.totalContributions,
+      samePeriodPreviousContributions || 0,
+      previousYearTotal || 0,
+      projectedYearTotal || 0,
+      periodDays,
+      current.year,
+      previous.year
+    )
+    narrativeInsights.push(...samePeriodInsights)
   } else {
-    narrativeInsights.push(`You matched last year's contribution count exactly.`)
+    // Full-year comparison insights (original logic)
+    if (contributionsPercentChange > 0) {
+      narrativeInsights.push(`You contributed ${contributionsPercentChange}% more than last year.`)
+    } else if (contributionsPercentChange < 0) {
+      narrativeInsights.push(`You contributed ${Math.abs(contributionsPercentChange)}% less than last year — quality over quantity.`)
+    } else {
+      narrativeInsights.push(`You matched last year's contribution count exactly.`)
+    }
   }
 
   // Consistency - show insight if consistency improved OR if active days delta exceeds threshold
-  if (consistencyImproved) {
-    if (activeDaysDelta > 0) {
-      narrativeInsights.push(`You were more consistent, coding ${activeDaysDelta} more days.`)
-    } else {
-      narrativeInsights.push(`You were more consistent this year.`)
+  // (Only show for full-year comparison or late in the year for same-period)
+  if (comparisonType === 'full-year' || (periodDays && periodDays > 180)) {
+    if (consistencyImproved) {
+      if (activeDaysDelta > 0) {
+        narrativeInsights.push(`You were more consistent, coding ${activeDaysDelta} more days.`)
+      } else {
+        narrativeInsights.push(`You were more consistent this year.`)
+      }
+    } else if (activeDaysDelta > ACTIVE_DAYS_DELTA_THRESHOLD) {
+      narrativeInsights.push(`You coded ${activeDaysDelta} more days than last year.`)
     }
-  } else if (activeDaysDelta > ACTIVE_DAYS_DELTA_THRESHOLD) {
-    narrativeInsights.push(`You coded ${activeDaysDelta} more days than last year.`)
   }
 
   // Streak
@@ -112,5 +405,10 @@ export function compareYears(
     droppedLanguages,
     consistencyImproved,
     narrativeInsights,
+    comparisonType,
+    periodDays,
+    samePeriodPreviousContributions,
+    projectedYearTotal,
+    previousYearTotal,
   }
 }

--- a/src/lib/export.test.ts
+++ b/src/lib/export.test.ts
@@ -76,6 +76,7 @@ describe('generateHTML', () => {
       busiestMonth: 'January',
       busiestMonthCount: 30,
       contributionsByMonth: [],
+      contributionCalendar: [],
     },
     craft: {
       primaryLanguage: 'TypeScript',
@@ -170,6 +171,7 @@ describe('generateHTML', () => {
           busiestMonth: malicious,
           busiestMonthCount: 30,
           contributionsByMonth: [],
+          contributionCalendar: [],
         },
         craft: {
           primaryLanguage: malicious,

--- a/src/lib/github/stats.test.ts
+++ b/src/lib/github/stats.test.ts
@@ -1038,4 +1038,62 @@ describe('processContributions', () => {
       expect(result.peakMoments.favoriteDaysOfWeek.length).not.toBe(7)
     })
   })
+
+  describe('contributionCalendar in rhythm output', () => {
+    it('includes daily contribution data in rhythm.contributionCalendar', () => {
+      const data = createMinimalResponse({
+        weeks: [
+          {
+            contributionDays: [
+              { date: '2024-01-01', contributionCount: 5, contributionLevel: 'FIRST_QUARTILE' },
+              { date: '2024-01-02', contributionCount: 3, contributionLevel: 'FIRST_QUARTILE' },
+              { date: '2024-01-03', contributionCount: 0, contributionLevel: 'NONE' },
+            ],
+          },
+        ],
+      })
+
+      const result = processContributions(data, 2024)
+
+      expect(result.rhythm.contributionCalendar).toBeDefined()
+      expect(result.rhythm.contributionCalendar).toHaveLength(3)
+      expect(result.rhythm.contributionCalendar[0]).toEqual({
+        date: '2024-01-01',
+        contributionCount: 5,
+        contributionLevel: 'FIRST_QUARTILE',
+      })
+    })
+
+    it('returns empty array when no contribution days exist', () => {
+      const data = createMinimalResponse({ weeks: [] })
+
+      const result = processContributions(data, 2024)
+
+      expect(result.rhythm.contributionCalendar).toEqual([])
+    })
+
+    it('flattens contribution days from multiple weeks', () => {
+      const data = createMinimalResponse({
+        weeks: [
+          {
+            contributionDays: [
+              { date: '2024-01-01', contributionCount: 1, contributionLevel: 'FIRST_QUARTILE' },
+              { date: '2024-01-02', contributionCount: 2, contributionLevel: 'FIRST_QUARTILE' },
+            ],
+          },
+          {
+            contributionDays: [
+              { date: '2024-01-08', contributionCount: 3, contributionLevel: 'FIRST_QUARTILE' },
+              { date: '2024-01-09', contributionCount: 4, contributionLevel: 'FIRST_QUARTILE' },
+            ],
+          },
+        ],
+      })
+
+      const result = processContributions(data, 2024)
+
+      expect(result.rhythm.contributionCalendar).toHaveLength(4)
+      expect(result.rhythm.contributionCalendar.map((d) => d.contributionCount)).toEqual([1, 2, 3, 4])
+    })
+  })
 })

--- a/src/lib/github/stats.ts
+++ b/src/lib/github/stats.ts
@@ -311,6 +311,7 @@ export function processContributions(
       busiestMonth: busiestMonthData.month,
       busiestMonthCount: busiestMonthData.count,
       contributionsByMonth,
+      contributionCalendar: allDays,
     },
     craft: {
       primaryLanguage,

--- a/src/lib/github/types.ts
+++ b/src/lib/github/types.ts
@@ -144,6 +144,7 @@ export interface YearStats {
     busiestMonth: string
     busiestMonthCount: number
     contributionsByMonth: { month: string; count: number }[]
+    contributionCalendar: ContributionDay[]
   }
   craft: {
     primaryLanguage: string


### PR DESCRIPTION
## Summary

- Add same-period YoY comparison for partial years (e.g., Jan 1-today of 2026 vs Jan 1-today of 2025)
- Add adaptive messaging based on how far into the year we are (Q1-Q4)
- Add year projection after 7+ days of data
- Preserve full-year comparison for complete years (>= 350 days)

## Problem

The current YoY comparison compares total contributions between years, which is misleading for the current year. For example, comparing 1 day of 2026 to all 365 days of 2025 shows "-99%".

## Solution

- When current year has < 350 days of data, use same-period comparison
- Compare Jan 1-today of current year vs Jan 1-today of previous year
- Generate adaptive narrative insights based on time of year:
  - **Days 1-30**: "Day 1 of 2026: 32 contributions. Same day last year: 0."
  - **Days 31-90 (Q1)**: Period comparison with trajectory projection
  - **Days 91-180 (Q2)**: Compare to last year's total
  - **Days 181-270 (Q3)**: Pace comparison
  - **Days 271-365 (Q4)**: Reliable projection with % complete

## Implementation

- Added `contributionCalendar` to `YearStats.rhythm` for daily contribution data access
- Added `getSamePeriodContributions()` helper to sum contributions up to a given date
- Added `calculateProjection()` function (only meaningful after 7+ days)
- Updated `YearComparison` interface with new fields:
  - `comparisonType: 'full-year' | 'same-period'`
  - `periodDays?: number`
  - `samePeriodPreviousContributions?: number`
  - `projectedYearTotal?: number`
  - `previousYearTotal?: number`

## Test Plan

- [x] Same-period comparison triggers when current year < 350 days
- [x] Full-year comparison still works for complete years
- [x] Projections only shown after 7+ days
- [x] Edge case: no data for same period last year
- [x] Adaptive messaging for each quarter
- [x] All existing tests pass
- [x] Type check passes
- [x] Lint passes

Fixes #16