### PR TITLE
feat: Add cache bypass refresh button in UI

### DIFF
--- a/src/app/rewind/page.tsx
+++ b/src/app/rewind/page.tsx
@@ -13,7 +13,7 @@ import { ProgressIndicator } from '@/components/ui'
 import { useScrollProgress, useKeyboardNavigation } from '@/hooks'
 import type { YearStats } from '@/lib/github'
 import { cn } from '@/lib/utils'
-import { getCached, setCache } from '@/lib/cache'
+import { getCached, setCache, clearCacheForYear } from '@/lib/cache'
 import { downloadRewind } from '@/lib/export'
 import { compareYears, type YearComparison } from '@/lib/comparisons'
 import { comparisonLogger } from '@/lib/logger'
@@ -32,6 +32,7 @@ export default function RewindPage() {
   const [error, setError] = useState<string | null>(null)
   const [selectedYear, setSelectedYear] = useState(CURRENT_YEAR)
   const [loadingYears, setLoadingYears] = useState<Set<number>>(new Set())
+  const [refreshing, setRefreshing] = useState(false)
 
   // Ref to track current year for race condition prevention in background fetches
   const currentYearRef = useRef(selectedYear)
@@ -204,6 +205,13 @@ export default function RewindPage() {
     }
   }, [fetchYearStats, computeComparison])
 
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true)
+    clearCacheForYear('stats', selectedYear)
+    await fetchStats(selectedYear)
+    setRefreshing(false)
+  }, [selectedYear, fetchStats])
+
   useEffect(() => {
     fetchStats(selectedYear)
   }, [selectedYear, fetchStats])
@@ -328,6 +336,34 @@ export default function RewindPage() {
             </button>
           )
         })}
+        <button
+          onClick={handleRefresh}
+          disabled={loading || refreshing}
+          className={cn(
+            'p-1.5 rounded-full transition-all duration-200',
+            'bg-bg-surface/50 text-text-tertiary',
+            'hover:bg-bg-elevated hover:text-text-secondary',
+            'disabled:opacity-50 disabled:cursor-not-allowed'
+          )}
+          aria-label="Refresh stats"
+          title="Refresh stats (bypass cache)"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={cn(refreshing && 'animate-spin')}
+          >
+            <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" />
+            <path d="M21 3v5h-5" />
+          </svg>
+        </button>
       </div>
 
       {/* Progress indicator */}

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -100,3 +100,17 @@ export function clearCache(prefix?: string): void {
     cacheLogger.error('Error clearing cache:', e)
   }
 }
+
+export function clearCacheForYear(prefix: string, year: number): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    const key = getCacheKey(prefix, year)
+    localStorage.removeItem(key)
+    cacheLogger.debug(`CLEARED cache for ${key}`)
+  } catch (e) {
+    cacheLogger.error('Error clearing cache for year:', e)
+  }
+}


### PR DESCRIPTION
## Summary

- Add a subtle refresh button next to the year selector that allows users to manually bypass the cache and fetch fresh GitHub stats data
- Add `clearCacheForYear` function to cache module for targeted cache clearing
- Button uses spinning animation during refresh and is disabled while loading

## Changes

### `src/lib/cache.ts`
- Added `clearCacheForYear(prefix: string, year: number)` function to clear cache for a specific year

### `src/app/rewind/page.tsx`
- Added `refreshing` state to track refresh operation
- Added `handleRefresh` callback that clears cache and re-fetches stats
- Added refresh button with:
  - Subtle icon-only design (14x14 refresh icon)
  - Spinning animation during refresh (`animate-spin`)
  - Disabled state while loading or refreshing
  - Tooltip explaining the action
  - Matches existing year button styling

## Test Plan

- [ ] Click refresh button - should clear cache and fetch fresh data
- [ ] Verify button shows spinning animation while refreshing
- [ ] Verify button is disabled while data is loading
- [ ] Verify button appears subtle and non-intrusive next to year selector
- [ ] Verify hover state provides visual feedback

Closes #20